### PR TITLE
Abstract page rendering process

### DIFF
--- a/app/data-injector.tsx
+++ b/app/data-injector.tsx
@@ -1,0 +1,20 @@
+import { ReactNode } from 'react';
+import ApolloClientProvider from './apollo-provider';
+import { InjectableProps } from './render-page';
+
+type DataInjectorProps = {
+  children: ReactNode | ((props?: InjectableProps) => ReactNode);
+  props?: InjectableProps;
+};
+
+export const DataInjector = async ({ children, props }: DataInjectorProps) => {
+  try {
+    return (
+      <ApolloClientProvider>
+        {typeof children === 'function' ? children(props) : children}
+      </ApolloClientProvider>
+    );
+  } catch (error) {
+    // Log error or do something else with it
+  }
+};

--- a/app/random-page.tsx
+++ b/app/random-page.tsx
@@ -1,0 +1,9 @@
+import renderPage from './render-page';
+
+const RandomPage = () => {
+  return renderPage(async () => {
+    return <div>Random Page</div>;
+  });
+};
+
+export default RandomPage;

--- a/app/render-page.tsx
+++ b/app/render-page.tsx
@@ -1,0 +1,31 @@
+import { Fragment, JSX } from 'react';
+import { DataInjector } from './data-injector';
+import { ApolloClient, NormalizedCacheObject } from '@apollo/client';
+import { redirect } from 'next/navigation';
+
+export type RenderProps = {
+  client: ApolloClient<NormalizedCacheObject>;
+};
+
+export type InjectableProps = {
+  client: ApolloClient<NormalizedCacheObject>;
+};
+
+const renderPage = async (render: (prop?: RenderProps) => Promise<JSX.Element> | JSX.Element) => {
+  try {
+    return (
+      <DataInjector>
+        {async (props) => {
+          const Component = await render(props);
+          return <Fragment>{Component}</Fragment>;
+        }}
+      </DataInjector>
+    );
+  } catch (error) {
+    // Handle error
+    // PS: This route does not exist at the moment
+    return redirect('/error');
+  }
+};
+
+export default renderPage;


### PR DESCRIPTION
Added a simple page renderer util. The render page simply returns a component which already encapsulates the ApolloProvider. You can pass in any injectable props you want inside of the render-page function in order to access it within the page itself.

I added a new `random-page` route as an example.